### PR TITLE
added timestampFormat setting

### DIFF
--- a/Classes/ComArihiroMessagestableView.m
+++ b/Classes/ComArihiroMessagestableView.m
@@ -105,6 +105,12 @@ TiMessagesTableViewController *controller;
     [self controller].timestampFont = [UIFont systemFontOfSize:((NSNumber *)argSize).floatValue];
 }
 
+- (void)setTimestampFormat_:(id)argFormat
+{
+    ENSURE_SINGLE_ARG(argFormat, NSString);
+    [[self controller].dateFormatter setDateFormat:(NSString *)argFormat];
+}
+
 - (void)setFailedAlert_:(id)alert
 {
     ENSURE_SINGLE_ARG(alert, NSString);

--- a/Classes/TiMessagesTableViewController.h
+++ b/Classes/TiMessagesTableViewController.h
@@ -27,6 +27,7 @@
 @property (nonatomic, strong) UIColor *timestampColor;
 @property (nonatomic, strong) UIFont *timestampFont;
 @property (nonatomic, strong) NSString *failedAlert;
+@property (nonatomic, strong) NSDateFormatter *dateFormatter;
 
 - (TiMessage *)addMessage:(NSString *)text sender:(NSString *)sender date:(NSDate *)date status:(MSG_STATUS_ENUM)status;
 - (NSUInteger)removeMessageWithMessageID:(NSUInteger)index;

--- a/Classes/TiMessagesTableViewController.m
+++ b/Classes/TiMessagesTableViewController.m
@@ -28,6 +28,7 @@ ComArihiroMessagestableModule *proxy;
 @synthesize timestampColor;
 @synthesize timestampFont;
 @synthesize failedAlert;
+@synthesize dateFormatter;
 
 CGRect originalTableViewFrame;
 BOOL isVisible;
@@ -48,6 +49,10 @@ BOOL isVisible;
     timestampColor = [UIColor lightGrayColor];
     failedAlert = @"failed to send.";
 
+    dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setLocale:[NSLocale currentLocale]];
+    [dateFormatter setDateStyle:NSDateFormatterNoStyle];
+    [dateFormatter setTimeStyle:NSDateFormatterShortStyle];
 
     [super viewDidLoad];
 
@@ -365,9 +370,7 @@ BOOL isVisible;
         if (message.status == MSG_FAILED) {
             cell.timestampLabel.text = failedAlert;
         } else {
-            cell.timestampLabel.text = [NSDateFormatter localizedStringFromDate:timestamp
-                                                                      dateStyle:NSDateFormatterNoStyle
-                                                                      timeStyle:NSDateFormatterShortStyle];
+            cell.timestampLabel.text = [dateFormatter stringFromDate:timestamp];
         }
     }
     

--- a/build_fat_lib.py
+++ b/build_fat_lib.py
@@ -12,4 +12,4 @@ for key, group in itertools.groupby(sorted(libs, key=first), first):
     print 'Run: %s' % cmd
     if os.system(cmd): raise Exception('Command failed: %s' % cmd)
 
-print '\nAll processes is completed!'
+print '\nAll fat libs are created successfully!'

--- a/example/app.js
+++ b/example/app.js
@@ -14,6 +14,7 @@ var view = TiMessagesTableViewController.createView({
   incomingColor: '#115', outgoingColor: '#511',
   senderColor: '#333', timestampColor: '#666',
   senderFontSize: 12, timestampFontSize: 9,
+  timestampFormat: 'MMM dd yyyy HH:mm:ss',
   failedAlert: 'Failed to send message!!',
   sendButtonText: 'Send!!'
 });


### PR DESCRIPTION
I implemented function to customize timestamp format.

This function can use by passing `timestampFormat` key-value to createView.

```
  var view = TiMessagesTableViewController.createView({
    height: 480, width: 320, backgroundColor: '#DDD',
    placeHolder: 'Please input message!', sender: 'ari_hiro',
    incomingBackgroundColor: '#88E', outgoingBackgroundColor: '#E88', failedBackgroundColor: '#E66',
    incomingColor: '#115', outgoingColor: '#511',
    senderColor: '#333', timestampColor: '#666',
    senderFontSize: 12, timestampFontSize: 9,
+   timestampFormat: 'MMM dd yyyy HH:mm:ss',
    failedAlert: 'Failed to send message!!',
    sendButtonText: 'Send!!'
  });
```

![2015-01-17 15 46 05](https://cloud.githubusercontent.com/assets/1583848/5788000/f93e3fa4-9e5f-11e4-8439-b0193a7ede5b.png)